### PR TITLE
added user's privacy checks

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :set_user, only: %i[ show liked feed followers following discover ]
+  before_action :respect_users_privacy, only: %i[ feed discover ]
 
   private
 
@@ -8,6 +9,14 @@ class UsersController < ApplicationController
         @user = User.find_by!(username: params.fetch(:username))
       else
         @user = current_user
+      end
+    end
+
+    def respect_users_privacy
+      if params[:username] != nil
+        if params[:username] != current_user.username
+          redirect_to root_path, alert: "Woah! Let's respect other's privacy!"
+        end
       end
     end
 end

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -49,22 +49,24 @@
         <% end %>
       </div>
 
-      <div class="col">
-        <%=
-          link_to "#",
-            data: { 
-              toggle: "modal", 
-              target: "##{dom_id(user)}_pending"
-            } do %>
+      <% if user == current_user %>
+        <div class="col">
+          <%=
+            link_to "#",
+              data: { 
+                toggle: "modal", 
+                target: "##{dom_id(user)}_pending"
+              } do %>
 
-          <span class="font-weight-bold">
-            <%= user.pending.size %>
-          </span>
-          
-          pending
+            <span class="font-weight-bold">
+              <%= user.pending.size %>
+            </span>
+            
+            pending
 
-        <% end %>
-      </div>
+          <% end %>
+        </div>
+      <% end %>
     </div>
 
     <div class="row mb-3">
@@ -142,10 +144,14 @@
     target: "#{dom_id(user)}_following"
 %>
 
-<%=
-  render "users/connected_users_modal.html.erb",
-    user: user,
-    connected_users: user.pending,
-    description: "pending",
-    target: "#{dom_id(user)}_pending"
-%>
+<% if user == current_user %>
+
+  <%=
+    render "users/connected_users_modal.html.erb",
+      user: user,
+      connected_users: user.pending,
+      description: "pending",
+      target: "#{dom_id(user)}_pending"
+  %>
+
+<% end %>

--- a/app/views/users/liked.html.erb
+++ b/app/views/users/liked.html.erb
@@ -4,16 +4,27 @@
   </div>
 </div>
 
-<div class="row mb-2">
-  <div class="col-md-6 offset-md-3">
-    <%= render "users/profile_nav", user: @user %>
-  </div>
-</div>
+<% am_i_follower = @user.followers.pluck(:username).include? current_user.username %>
 
-<% @user.liked_photos.each do |photo| %>
-  <div class="row mb-4">
+<% if !@user.private || am_i_follower || @user == current_user %>
+
+  <div class="row mb-2">
     <div class="col-md-6 offset-md-3">
-      <%= render "photos/photo", photo: photo %>
+      <%= render "users/profile_nav", user: @user %>
     </div>
   </div>
-<% end %>
+
+  <% @user.liked_photos.each do |photo| %>
+    <div class="row mb-4">
+      <div class="col-md-6 offset-md-3">
+        <%= render "photos/photo", photo: photo %>
+      </div>
+    </div>
+  <% end %>
+
+<% else %>
+  <div class="alert alert-secondary text-center">
+    <p class="small my-0 mx-auto"><%= @user.name %> has requested their account to be private</p>
+    <p class="small my-0 mx-auto">Let's respect that and be kind to each other.</p>
+  </div>
+ <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,16 +4,26 @@
   </div>
 </div>
 
-<div class="row mb-2">
-  <div class="col-md-6 offset-md-3">
-    <%= render "users/profile_nav", user: @user %>
-  </div>
-</div>
+<% am_i_follower = @user.followers.pluck(:username).include? current_user.username %>
 
-<% @user.own_photos.each do |photo| %>
-  <div class="row mb-4">
+<% if !@user.private || am_i_follower || @user == current_user %>
+  <div class="row mb-2">
     <div class="col-md-6 offset-md-3">
-      <%= render "photos/photo", photo: photo %>
+      <%= render "users/profile_nav", user: @user %>
     </div>
+  </div>
+
+  <% @user.own_photos.each do |photo| %>
+    <div class="row mb-4">
+      <div class="col-md-6 offset-md-3">
+        <%= render "photos/photo", photo: photo %>
+      </div>
+    </div>
+  <% end %>
+
+<% else %>
+  <div class="alert alert-secondary text-center">
+    <p class="small my-0 mx-auto"><%= @user.name %> has requested their account to be private</p>
+    <p class="small my-0 mx-auto">Let's respect that and be kind to each other.</p>
   </div>
 <% end %>


### PR DESCRIPTION
* Users should not be able to edit / delete other's photos and comments
* Users should not be able to see other's pending requests
* Users should bot be able to see _private_ user's likes and posts
* For additional security, User's pending follow request modal is not rendered in the HTML. It could have been forced opened by a user by changing the _data-target_ attribute if the modal is rendered and only the _pending_ link is not made visible.